### PR TITLE
Update documentation regarding beacon proximity event

### DIFF
--- a/documentation/using-the-sdk.md
+++ b/documentation/using-the-sdk.md
@@ -297,7 +297,8 @@ Fired when device enters or leaves a beacon proximity. Normally you don't need t
 
 intent Extras: 
 
-* EVENT\_PROXIMITY\_EXTRADATA\_BEACON - beacon id
+* EVENT\_PROXIMITY\_EXTRADATA\_BEACON - json object containing beacon details  
+  ```{"accuracy": 10.233, "major": 1200, "minor": 101, "proximity": "FAR", "rssi": -88, "txpower": -63, "uuid": "92517B9E-7DB2-4275-913E-AA20DA8A15CC"}```
 * EVENT\_PROXIMITY\_EXTRADATA\_PROXIMITY - near/far/immediate
 * EVENT\_PROXIMITY\_EXTRADATA\_INOUT - "i" or "o" - enter or exit
 


### PR DESCRIPTION
While implementing the LocalBroadcastReceiver in our application I found that the data that is sent for proximity events does not match with what the documentation describes. 

This could of course also be a bug in the implementation, but that I don't know.